### PR TITLE
Proper pixel metrics + empty title handling + center align by default

### DIFF
--- a/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
+++ b/app/src/main/java/com/jasonette/seed/Core/JasonViewActivity.java
@@ -2144,6 +2144,9 @@ public class JasonViewActivity extends AppCompatActivity {
         try {
             menu = toolbar.getMenu();
             if (model.rendered != null) {
+                if(!model.rendered.has("header")){
+                    setup_title(new JSONObject());
+                }
                 JSONObject header = model.rendered.getJSONObject("header");
 
                 header_height = toolbar.getHeight();
@@ -2361,6 +2364,10 @@ public class JasonViewActivity extends AppCompatActivity {
 
             if (header.has("title")) {
                 Object title = header.get("title");
+
+                // set align:center by default
+                toolbar.setAlignment(Gravity.CENTER);
+
                 if (title instanceof String) {
                     toolbar.setTitle(header.getString("title"));
                     if(logoView != null){
@@ -2397,12 +2404,12 @@ public class JasonViewActivity extends AppCompatActivity {
                         int topOffset = 0;
 
                         try {
-                            leftOffset = style.getInt("left");
+                            leftOffset = (int)JasonHelper.pixels(JasonViewActivity.this, style.getString("left"), "horizontal");
                         } catch (JSONException e) {
                         }
 
                         try {
-                            topOffset = style.getInt("top");
+                            topOffset = (int)JasonHelper.pixels(JasonViewActivity.this, style.getString("top"), "vertical");
                         } catch (JSONException e) {
                         }
 


### PR DESCRIPTION
1. **Proper pixel metrics**
    Pixels should be calculated using `JasonHelper.pixels()` to make it fit every screen size
2. **Empty title handling**
    `setup_title` wasn't being called when there was no `header` attribute. This should be called even when there's no `header` so that the title gets set to an empty one.
3. **Center align by default**
    Align title center by default for consistency. Users can decide to left align if they want using the `align: left` option